### PR TITLE
feat: add temporary banner marking the content as alpha

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -56,10 +56,9 @@ footer = "<a href=\"https://blubracket.com/\">BluBracket</a> code security track
 copyRight = "Copyright (c) 2019-2021 BluBracket"
 
 # Alert
-alert = false
+alert = true
 alertDismissable = true
-# alertText = "Introducing the Doks child theme, several DX + UX updates, and more! <a class=\"alert-link stretched-link\" href=\"https://getdoks.org/blog/doks-v0.2/\" target=\"_blank\" rel=\"noopener\">Check out Doks v0.2</a>"
-alertText = "Introducing the Doks child theme, several DX + UX updates, and more! <a class=\"alert-link stretched-link\" href=\"https://getdoks.org/blog/doks-v0.2/\">Check out Doks v0.2</a>"
+alertText = "These docs are in alpha. We're actively developing them, and we invite you to <a class=\"alert-link stretched-link\" href=\"https://github.com/BluBracket/docs.blubracket.com\">open an issue or PR with any suggestions</a>, but we're not currently allowing indexing and recommend <a class=\"alert-link stretched-link\" href=\"https://support.blubracket.com\">the docs at support.blubracket.com</a> for any production questionsat this time."
 
 # Edit Page
 # repoHost [Github | Gitea | GitLab] is used for building the edit link based on git hoster


### PR DESCRIPTION
Banner can be removed by commenting out the config line