### PR TITLE
DO NOT MERGE feat: make indexable, remove banner, go-live

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -56,7 +56,7 @@ footer = "<a href=\"https://blubracket.com/\">BluBracket</a> code security track
 copyRight = "Copyright (c) 2019-2021 BluBracket"
 
 # Alert
-alert = true
+alert = false
 alertDismissable = true
 alertText = "This preview of our new documentation site is in active development. We recommend <a class=\"alert-link stretched-link\" href=\"https://support.blubracket.com\">the docs at support.blubracket.com</a> for any production questions at this time."
 

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /


### PR DESCRIPTION
This removes the `robots.txt` that blocks indexing and the banner alerting people to the development status.