### PR TITLE
style: branded blue

### DIFF
--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -19,7 +19,7 @@ $beige:    #fbf7f0;
 // $red:      #e55235;
 $purple:   #5d2f86;
 $brown:    #aa9c84;
-$blue:     #193DD6;
+$blue:     #193dd6;
 
 $blue-300: #8ed6fb;
 $pink-100: #fcfaff;

--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -19,12 +19,13 @@ $beige:    #fbf7f0;
 // $red:      #e55235;
 $purple:   #5d2f86;
 $brown:    #aa9c84;
+$blue:     #193DD6;
 
 $blue-300: #8ed6fb;
 $pink-100: #fcfaff;
 $pink-500: #d32e9d;
 
-$primary: $purple;
+$primary: $blue;
 
 $color-btn-bg: $pink-500;
 $color-btn-border: darken($pink-500, 5%);

--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -132,7 +132,7 @@ button#doks-versions {
 
 .header-bar {
   border-top: 4px solid;
-  border-image-source: linear-gradient(90deg, $primary, #8ed6fb 50%, #d32e9d);
+  border-image-source: linear-gradient(90deg, $primary, $primary 50%, $gray-800);
   border-image-slice: 1;
 }
 


### PR DESCRIPTION
Not intended to be a perfect change, just incrementally better.

Preview of the BluBracket-branded blue:

<img width="1595" alt="Screen Shot 2022-03-01 at 7 11 14 AM" src="https://user-images.githubusercontent.com/1709697/156194734-70775794-6b2a-4ee0-8e6d-8ae5b732ce65.png">

<img width="1595" alt="Screen Shot 2022-03-01 at 7 11 22 AM" src="https://user-images.githubusercontent.com/1709697/156194791-1b5b6e68-51bc-4d11-af9d-a54300b01a16.png">

