### PR TITLE
feat: support for search hints to help map search queries to the right content

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -108,7 +108,19 @@ Source:
         {{ else -}}
           description: {{ .Summary | plainify | jsonify }},
         {{ end -}}
-        content: {{ .Plain | jsonify }}
+        {{ if .Params.tags }}
+          {{ range $index, $tag := .Params.tags }}
+            {{ $.Scratch.Add "content" ( printf "%s" $tag ) }}
+          {{ end }}
+        {{ end }}
+        {{ if .Params.searchExtraKeywords }}
+          {{ range $index, $tag := .Params.searchExtraKeywords }}
+            {{ $.Scratch.Add "content" ( printf "%s" $tag ) }}
+          {{ end }}
+        {{ end }}
+        {{ $.Scratch.Add "content" .Plain }}
+        content: {{ $.Scratch.Get "content" | plainify | jsonify }}
+        {{ $.Scratch.Delete "content" }}
       })
       {{ if ne (add $index 1) $len -}}
         .add(

--- a/content/intro/getting-started/index.md
+++ b/content/intro/getting-started/index.md
@@ -8,13 +8,16 @@ weight: 300
 toc: true
 tags:
   - free trial
+searchExtraKeywords:
+  - "Getting Started with BluBracket Teams and Enterprise Editions - BluBracket"
+  - "Getting Started with the Free Trial - BluBracket"
 resources:
-- src: three-step-process-sign-up.png
-- src: enter-email-get-started.png
-- src: submit-email-and-get-confirmation-page.png
-- src: getting-to-set-your-blubracket-password.png
-- src: signup6.jpg
-- src: login-blubracket-page.png
+  - src: three-step-process-sign-up.png
+  - src: enter-email-get-started.png
+  - src: submit-email-and-get-confirmation-page.png
+  - src: getting-to-set-your-blubracket-password.png
+  - src: signup6.jpg
+  - src: login-blubracket-page.png
 ---
 {{< youtube ZHLOezVag7I >}}
 


### PR DESCRIPTION
Example search URLs that this can support

- https://docs.blubracket.com/?s=Getting%20Started%20with%20BluBracket%20Teams%20and%20Enterprise%20Editions%20–%20BluBracket
- https://docs.blubracket.com/?s=How%20To%20Generate%20Personal%20Access%20Token%20(PAT)%20in%20GitHub%20–%20BluBracket
- https://docs.blubracket.com/?s=CI%20secret%20scanning%20for%20Azure%20Pipelines%20–%20BluBracket
- https://docs.blubracket.com/?s=Getting%20Started%20with%20the%20Free%20Trial%20–%20BluBracket
- https://docs.blubracket.com/?s=Configuring%20Infrastructure%20as%20Code%20on%20Bitbucket%20–%20BluBracket
- https://docs.blubracket.com/?s=Configuring%20Infrastructure%20as%20Code%20on%20GitHub%20–%20BluBracket
- https://docs.blubracket.com/?s=Event%20and%20Alert%20APIs%20–%20BluBracket

