### PR TITLE
chore: revert unintional changes introduced in #119

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
-      "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.7.tgz",
+      "integrity": "sha512-djHlEfFHnSnTAcPb7dATbiM5HxGOP98+3JLBZtjRb5I7RXrw7kFRoG2dXM8cm3H+o11A8IFH/uprmJpwFynRNQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
@@ -111,8 +111,8 @@
         "@babel/generator": "^7.17.7",
         "@babel/helper-compilation-targets": "^7.17.7",
         "@babel/helper-module-transforms": "^7.17.7",
-        "@babel/helpers": "^7.17.8",
-        "@babel/parser": "^7.17.8",
+        "@babel/helpers": "^7.17.7",
+        "@babel/parser": "^7.17.7",
         "@babel/template": "^7.16.7",
         "@babel/traverse": "^7.17.3",
         "@babel/types": "^7.17.0",
@@ -469,9 +469,9 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
-      "integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.7.tgz",
+      "integrity": "sha512-TKsj9NkjJfTBxM7Phfy7kv6yYc4ZcOo+AaWGqQOKTPDOmcGkIFb5xNA746eKisQkm4yavUYh4InYM9S+VnO01w==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.16.7",
@@ -497,9 +497,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.7.tgz",
+      "integrity": "sha512-bm3AQf45vR4gKggRfvJdYJ0gFLoCbsPxiFLSH6hTVYABptNHY6l9NrhnucVjQ/X+SPtLANT9lc0fFhikj+VBRA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -7753,9 +7753,9 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
-      "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.7.tgz",
+      "integrity": "sha512-djHlEfFHnSnTAcPb7dATbiM5HxGOP98+3JLBZtjRb5I7RXrw7kFRoG2dXM8cm3H+o11A8IFH/uprmJpwFynRNQ==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
@@ -7763,8 +7763,8 @@
         "@babel/generator": "^7.17.7",
         "@babel/helper-compilation-targets": "^7.17.7",
         "@babel/helper-module-transforms": "^7.17.7",
-        "@babel/helpers": "^7.17.8",
-        "@babel/parser": "^7.17.8",
+        "@babel/helpers": "^7.17.7",
+        "@babel/parser": "^7.17.7",
         "@babel/template": "^7.16.7",
         "@babel/traverse": "^7.17.3",
         "@babel/types": "^7.17.0",
@@ -8030,9 +8030,9 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
-      "integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.7.tgz",
+      "integrity": "sha512-TKsj9NkjJfTBxM7Phfy7kv6yYc4ZcOo+AaWGqQOKTPDOmcGkIFb5xNA746eKisQkm4yavUYh4InYM9S+VnO01w==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.16.7",
@@ -8052,9 +8052,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.7.tgz",
+      "integrity": "sha512-bm3AQf45vR4gKggRfvJdYJ0gFLoCbsPxiFLSH6hTVYABptNHY6l9NrhnucVjQ/X+SPtLANT9lc0fFhikj+VBRA==",
       "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {


### PR DESCRIPTION
See history of the file: https://github.com/BluBracket/docs.blubracket.com/commits/main/package-lock.json

https://github.com/BluBracket/docs.blubracket.com/pull/119 introduced an unexpected change. This reverts it.

I'm expecting that GitHub's DependaBot will re-do https://github.com/BluBracket/docs.blubracket.com/pull/121 following this.